### PR TITLE
Use separate session for oauth login and regular login

### DIFF
--- a/_dependencies.php
+++ b/_dependencies.php
@@ -41,8 +41,30 @@ use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use League\OAuth2\Server\ResourceServer;
 use Psr\Container\ContainerInterface;
+use RKA\SessionMiddleware;
 
 $container = $app->getContainer();
+
+//$app->add($session);
+$container->set(
+    'oauth_session',
+    function (ContainerInterface $container) {
+        $session_name = PREFIX_DB . '_' . NAME_DB . '_' . str_replace('.', '_', GALETTE_VERSION);
+        $session_name = 'galette_oauth_' . $session_name;
+        $session = new SessionMiddleware([
+            'name'      => $session_name,
+            'lifetime'  => GALETTE_TIMEOUT
+        ]);
+
+        $galette_sid = session_id();
+        session_write_close();
+        session_id('galette-oauth-' . $galette_sid);
+        $session->start();
+
+        $container->get('flash')->__construct($_SESSION);
+        return new \RKA\Session();
+    }
+);
 
 $container->set(
     Config::class,

--- a/_routes.php
+++ b/_routes.php
@@ -39,7 +39,7 @@ require_once 'vendor/autoload.php';
 //Constants and classes from plugin
 require_once $module['root'] . '/_config.inc.php';
 
-require_once '_dependencies.php';
+require '_dependencies.php';
 
 //login is always called by a http_redirect
 $app->get(

--- a/_routes.php
+++ b/_routes.php
@@ -42,11 +42,15 @@ require_once $module['root'] . '/_config.inc.php';
 require_once '_dependencies.php';
 
 //login is always called by a http_redirect
-$app->map(
-    ['GET', 'POST'],
+$app->get(
     '/login',
     [LoginController::class, 'login']
 )->setName(OAUTH2_PREFIX . '_login');
+
+$app->post(
+    '/login',
+    [LoginController::class, 'doLogin']
+)->setName(OAUTH2_PREFIX . '_doLogin');
 
 $app->map(
     ['GET', 'POST'],

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,9 @@
         {
             "name": "Manuel H",
             "email": "manuelh78dev@ik.me"
+        }, {
+            "name": "Johan Cwiklinski",
+            "email": "trasher@x-tnd.be"
         }
     ],
     "require": {

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -46,7 +46,7 @@ final class UserHelper
         /** @var Login $login */
         $login = $container->get('login');
         $history = $container->get('history');
-        $session = $container->get('session');
+        $session = $container->get('oauth_session');
         $flash = $container->get('flash');
 
         if (trim($nick) === '' || trim($password) === '') {
@@ -92,7 +92,7 @@ final class UserHelper
         /** @var Login $login */
         $login = $container->get('login');
         $history = $container->get('history');
-        $session = $container->get('session');
+        $session = $container->get('oauth_session');
 
         $login->logout();
         $session->login = $login;

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -66,6 +66,10 @@ final class UserHelper
             }
 
             if ($pw_superadmin) {
+                Analog::log(
+                    'OAuth login attempt from superadmin account',
+                    Analog::WARNING
+                );
                 $flash->addMessage(
                     'error_detected',
                     _T('Cannot OAuth login from superadmin account!', 'oauth2')

--- a/lib/GaletteOAuth2/Controllers/ApiController.php
+++ b/lib/GaletteOAuth2/Controllers/ApiController.php
@@ -32,6 +32,7 @@ use GaletteOAuth2\Authorization\UserHelper;
 use GaletteOAuth2\Tools\Config;
 use GaletteOAuth2\Tools\Debug;
 use League\OAuth2\Server\ResourceServer;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -50,6 +51,8 @@ final class ApiController extends AbstractPluginController
     protected array $module_info;
     protected Container $container;
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     /**
      * Default constructor

--- a/lib/GaletteOAuth2/Controllers/AuthorizationController.php
+++ b/lib/GaletteOAuth2/Controllers/AuthorizationController.php
@@ -36,6 +36,7 @@ use GaletteOAuth2\Tools\Debug as Debug;
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Http\Message\ResponseInterface;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -54,6 +55,8 @@ final class AuthorizationController extends AbstractPluginController
     protected array $module_info;
     protected Container $container;
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     /**
      * Default constructor

--- a/lib/GaletteOAuth2/Controllers/LoginController.php
+++ b/lib/GaletteOAuth2/Controllers/LoginController.php
@@ -30,6 +30,7 @@ use GaletteOAuth2\Authorization\UserAuthorizationException;
 use GaletteOAuth2\Authorization\UserHelper;
 use GaletteOAuth2\Tools\Config;
 use GaletteOAuth2\Tools\Debug;
+use RKA\Session;
 use Slim\Psr7\Request;
 use Slim\Psr7\Response;
 
@@ -50,6 +51,8 @@ final class LoginController extends AbstractPluginController
     protected Container $container;
     #[Inject]
     protected Config $config;
+    #[Inject("oauth_session")]
+    protected Session $session;
 
     /**
      * Display login form
@@ -109,7 +112,6 @@ final class LoginController extends AbstractPluginController
         //FIXME: for both isLoggedIn and user_id, we can rely on login object stored in session
         $this->session->isLoggedIn = 'no';
         $this->session->user_id = $uid = UserHelper::login($this->container, $params['login'], $params['password']);
-        //if($params['login'] == 'manuel') $loginSuccessful = true;
         Debug::log("UserHelper::login({$params['login']}) return '{$uid}'");
 
         if (false === $uid) {

--- a/lib/GaletteOAuth2/Controllers/LoginController.php
+++ b/lib/GaletteOAuth2/Controllers/LoginController.php
@@ -46,51 +46,57 @@ final class LoginController extends AbstractPluginController
      */
     #[Inject("Plugin Galette OAuth2")]
     protected array $module_info;
+    #[Inject]
     protected Container $container;
+    #[Inject]
     protected Config $config;
 
     /**
-     * Default constructor
+     * Display login form
      *
-     * @param Container $container Container instance
-     * @throws \DI\DependencyException
-     * @throws \DI\NotFoundException
+     * @param Request  $request  Received request
+     * @param Response $response Response instance
+     *
+     * @return Response
      */
-    public function __construct(Container $container)
-    {
-        $this->container = $container;
-        $this->config = $this->container->get(Config::class);
-        parent::__construct($container);
-    }
-
     public function login(Request $request, Response $response): Response
     {
         Debug::logRequest('login()', $request);
 
-        if ($request->getMethod() === 'GET') {
-            $redirect_url = $request->getQueryParams()['redirect_url'] ?? false;
+        $redirect_url = $request->getQueryParams()['redirect_url'] ?? false;
 
-            if ($redirect_url) {
-                $url = urldecode($redirect_url);
-                $url_query = parse_url($url, PHP_URL_QUERY);
-                parse_str($url_query, $url_args);
-                $this->session->request_args = $url_args;
-            }
-
-            /** @phpstan-ignore-next-line */
-            if (OAUTH2_DEBUGSESSION) {
-                Debug::log('GET _SESSION = ' . Debug::printVar($this->session));
-            }
-
-            // display page
-            $this->view->render(
-                $response,
-                $this->getTemplate(OAUTH2_PREFIX . '_login'),
-                $this->prepareVarsForm()
-            );
-            return $response;
+        //FIXME: redirect URL seems required: session request_args is considered as existing in self::prepareVarsForm()
+        if ($redirect_url) {
+            $url = urldecode($redirect_url);
+            $url_query = parse_url($url, PHP_URL_QUERY);
+            parse_str($url_query, $url_args);
+            $this->session->request_args = $url_args;
         }
 
+        /** @phpstan-ignore-next-line */
+        if (OAUTH2_DEBUGSESSION) {
+            Debug::log('GET _SESSION = ' . Debug::printVar($this->session));
+        }
+
+        // display page
+        $this->view->render(
+            $response,
+            $this->getTemplate(OAUTH2_PREFIX . '_login'),
+            $this->prepareVarsForm()
+        );
+        return $response;
+    }
+
+    /**
+     * Do login
+     *
+     * @param Request  $request  Received request
+     * @param Response $response Response instance
+     *
+     * @return Response
+     */
+    public function doLogin(Request $request, Response $response): Response
+    {
         /** @phpstan-ignore-next-line */
         if (OAUTH2_DEBUGSESSION) {
             Debug::log('POST _SESSION = ' . Debug::printVar($this->session));

--- a/lib/GaletteOAuth2/Middleware/Authentication.php
+++ b/lib/GaletteOAuth2/Middleware/Authentication.php
@@ -45,7 +45,7 @@ final class Authentication
     public function __construct(Container $container)
     {
         $this->routeparser = $container->get(RouteParser::class);
-        $this->session = $container->get('session');
+        $this->session = $container->get('oauth_session');
     }
 
     /**

--- a/lib/GaletteOAuth2/Repositories/ClientRepository.php
+++ b/lib/GaletteOAuth2/Repositories/ClientRepository.php
@@ -47,7 +47,7 @@ final class ClientRepository implements ClientRepositoryInterface
     {
         $this->container = $container;
         $this->config = $this->container->get(Config::class);
-        $this->session = $this->container->get('session');
+        $this->session = $this->container->get('oauth_session');
     }
 
     public function getClientEntity($client_id): ClientEntityInterface

--- a/templates/default/oauth2_login.html.twig
+++ b/templates/default/oauth2_login.html.twig
@@ -1,4 +1,4 @@
 {% extends "pages/index.html.twig" %}
 
 {% set ext_auth = true %}
-{% block form_url %}{{ url_for('oauth2_login') }}{% endblock %}
+{% block form_url %}{{ url_for('oauth2_doLogin') }}{% endblock %}

--- a/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
+++ b/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
@@ -32,6 +32,21 @@ use PHPUnit\Framework\Attributes\DataProvider;
 class UserHelper extends GaletteTestCase
 {
     protected int $seed = 20230324120838;
+    protected bool $load_plugins = true;
+
+    /**
+     * Set up tests
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        global $session;
+
+        parent::setUp();
+        $this->session = $this->container->get('oauth_session');
+        $session = $this->session;
+    }
 
     /**
      * Tear down tests

--- a/tests/GaletteOAuth2/Controllers/tests/units/LoginController.php
+++ b/tests/GaletteOAuth2/Controllers/tests/units/LoginController.php
@@ -1,0 +1,156 @@
+<?php
+
+/**
+ * Copyright © 2021-2025 The Galette Team
+ *
+ * This file is part of Galette OAuth2 plugin (https://galette-community.github.io/plugin-oauth2/).
+ *
+ * Galette is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Galette is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Galette OAuth2 plugin. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace GaletteOAuth2\Controllers\tests\units;
+
+use Galette\GaletteRoutingTestCase;
+
+/**
+ * Login controller tests
+ *
+ * @author Johan Cwiklinski <johan@x-tnd.be>
+ */
+class LoginController extends GaletteRoutingTestCase
+{
+    protected int $seed = 20250921223808;
+    protected bool $load_plugins = true;
+
+    /**
+     * Set up tests
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        global $session;
+        parent::setUp();
+
+        $this->session = $this->container->get('oauth_session');
+        $session = $this->session;
+    }
+
+    /**
+     * Tear down tests
+     *
+     * @return void
+     */
+    public function tearDown(): void
+    {
+        $this->zdb = new \Galette\Core\Db();
+
+        $this->cleanMembers();
+        parent::tearDown();
+    }
+
+    /**
+     * Test display login page
+     *
+     * @return void
+     */
+    public function testLogin(): void
+    {
+        $this->assertArrayNotHasKey('plugin-oauth2', $this->plugins->getDisabledModules());
+        $this->assertArrayHasKey('plugin-oauth2', $this->plugins->getModules());
+
+        $route_name = OAUTH2_PREFIX . '_login';
+        $query_params = [
+            'redirect_url' => $this->routeparser->urlFor(
+                OAUTH2_PREFIX . '_authorize',
+                [],
+                [
+                    'scope' => 'member',
+                    'state' => '7d627422092a7a5ac413ac597312b9b4',
+                    'response_type' => 'code',
+                    'approval_prompt' => 'auto',
+                    'redirect_uri' => 'http://flarum.localhost/auth/passport',
+                    'client_id' => 'galette_flarum'
+                ]
+            )
+        ];
+        $request = $this->createRequest(
+            route_name: $route_name,
+            query_params: $query_params
+        );
+
+        $test_response = $this->app->handle($request);
+        $this->expectOK($test_response);
+        $body = (string)$test_response->getBody();
+        $this->assertStringContainsString('Sign in Forum Flarum', $body);
+    }
+
+    /**
+     * Test login
+     *
+     * @return void
+     */
+    public function testDoLogin(): void
+    {
+        $this->assertArrayNotHasKey('plugin-oauth2', $this->plugins->getDisabledModules());
+        $this->assertArrayHasKey('plugin-oauth2', $this->plugins->getModules());
+
+        $route_name = OAUTH2_PREFIX . '_login';
+        $query_params = [
+            'redirect_url' => $this->routeparser->urlFor(
+                OAUTH2_PREFIX . '_authorize',
+                [],
+                [
+                    'scope' => 'member',
+                    'state' => '7d627422092a7a5ac413ac597312b9b4',
+                    'response_type' => 'code',
+                    'approval_prompt' => 'auto',
+                    'redirect_uri' => 'http://flarum.localhost/auth/passport',
+                    'client_id' => 'galette_flarum'
+                ]
+            )
+        ];
+        $request = $this->createRequest(
+            route_name: $route_name,
+            query_params: $query_params,
+            method: 'POST'
+        );
+
+        $request = $request->withParsedBody([
+            'login' => 'jdoe',
+            'password' => 'password'
+        ]);
+        $test_response = $this->app->handle($request);
+        $this->assertSame(['Location' => [$this->routeparser->urlFor(OAUTH2_PREFIX . '_login')]], $test_response->getHeaders());
+        $this->assertSame(301, $test_response->getStatusCode());
+        $this->expectLogEntry(
+            \Analog::WARNING,
+            'No entry found for login `jdoe`'
+        );
+        //flash data are stored in plugin specific session... No way from tests to check them, including on redirected page
+
+        $request = $request->withParsedBody([
+            'login' => 'admin',
+            'password' => 'admin'
+        ]);
+        $test_response = $this->app->handle($request);
+        $this->assertSame(['Location' => [$this->routeparser->urlFor(OAUTH2_PREFIX . '_login')]], $test_response->getHeaders());
+        $this->assertSame(301, $test_response->getStatusCode());
+        $this->expectLogEntry(
+            \Analog::WARNING,
+            'OAuth login attempt from superadmin account'
+        );
+        //flash data are stored in plugin specific session... No way from tests to check them, including on redirected page
+    }
+}

--- a/tests/GaletteOAuth2/GaletteOAuth2.php
+++ b/tests/GaletteOAuth2/GaletteOAuth2.php
@@ -31,6 +31,21 @@ use Galette\GaletteTestCase;
 class GaletteOAuth2 extends GaletteTestCase
 {
     protected int $seed = 20240613200350;
+    protected bool $load_plugins = true;
+
+    /**
+     * Set up tests
+     *
+     * @return void
+     */
+    public function setUp(): void
+    {
+        global $session;
+
+        parent::setUp();
+        $this->session = $this->container->get('oauth_session');
+        $session = $this->session;
+    }
 
     /**
      * Tear down tests


### PR DESCRIPTION
This way:
- existing loggedin user won't be used and won't be logged out
- no user will stay loggedin after oauth redirect