### PR TITLE
Remove specific data

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ cd plugin-oauth2
 composer install
 ```
 
+# Updating to version 3.0.0
+
+Before updating to version 3.0.0, please take care of the following:
+- the existing `options` entry in configuration file has been renamed to `authorize`. Please update your configuration file accordingly.
+- the `scopes` entry in configuration file has been added; some data you were previously using may be missing.
+- previous versions were using non Galette data (like `username`). If you were using this data and still want to rely on them; add a `legacy_data: true` in you applications entries.
+
 # Configuration
 
 ## Prepare public/private keys
@@ -27,7 +34,7 @@ copy-paste the hexadecimal string result in plugin-oauth2/config/encryption-key.
 
 ## Configure a ClientEntity
 
-Rename `config/config.yml.dist` to `config/config.yml` and edit according to your third party applicaiton settings:
+Rename `config/config.yml.dist` to `config/config.yml` and edit according to your third party application settings:
 
 ```
 global:
@@ -51,7 +58,6 @@ The corresponding Flarum configuration:
 The corresponding NextCloud configuration:
 
 ![Nextcloud configuration example](examples/nextcloud.png)
-
 
 ### Available authorizations:
 

--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -106,13 +106,15 @@ final class UserHelper
      * @param int          $id        User ID
      * @param string       $acl       Requested authorization
      * @param array|string $scopes    Scopes
+     * @param bool         $legacy    Legacy mode for data
+     *
      * @return array
      * @throws UserAuthorizationException
      * @throws \DI\DependencyException
      * @throws \DI\NotFoundException
      * @throws \Throwable
      */
-    public static function getUserData(Container $container, int $id, string $acl, array|string $scopes): array
+    public static function getUserData(Container $container, int $id, string $acl, array|string $scopes, bool $legacy = false): array
     {
         /** @var Db $zdb */
         $zdb = $container->get('zdb');
@@ -160,25 +162,29 @@ final class UserHelper
             );
         }
 
-        //FIXME: I really doubt reworking names is a good idea outside a specific usage
-        $nameExplode = preg_split('/[\\s,-]+/', $member->name);
-        if (count($nameExplode) > 0) {
-            $nameFPart = $nameExplode[0];
-            //too short?
-            if (mb_strlen($nameFPart) < 4 && count($nameExplode) > 1) {
-                $nameFPart .= $nameExplode[1];
-            }
-        } else {
-            $nameFPart = $member->name;
-        }
+        $login = $member->login;
 
-        //Normalized format s.name (example mail usage : s.name@xxxx.xx )
-        //FIXME: why don't use email directly?
-        $norm_login = sprintf(
-            '%s.%s',
-            mb_substr(self::stripAccents($member->surname), 0, 1),
-            self::stripAccents($nameFPart)
-        );
+        if ($legacy === true) {
+            //FIXME: I really doubt reworking names is a good idea outside a specific usage
+            $nameExplode = preg_split('/[\\s,-]+/', $member->name);
+            if (count($nameExplode) > 0) {
+                $nameFPart = $nameExplode[0];
+                //too short?
+                if (mb_strlen($nameFPart) < 4 && count($nameExplode) > 1) {
+                    $nameFPart .= $nameExplode[1];
+                }
+            } else {
+                $nameFPart = $member->name;
+            }
+
+            //Normalized format s.name (example mail usage : s.name@xxxx.xx )
+            //FIXME: why don't use email directly?
+            $login = sprintf(
+                '%s.%s',
+                mb_substr(self::stripAccents($member->surname), 0, 1),
+                self::stripAccents($nameFPart)
+            );
+        }
 
         //FIXME: be compliant with OpenID-Connect (see https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims)
         $oauth_data = [
@@ -187,8 +193,8 @@ final class UserHelper
             'identifier' => $member->id, //nextcloud
             'name' => $member->sfullname, //OpenID-Connect
             'displayName' => $member->sname,
-            'username' => $norm_login, //FIXME: $member->login,
-            'userName' => $norm_login, //FIXME: $member->login,
+            'username' => $login,
+            'userName' => $login,
             'email' => $member->email,
             'mail' => $member->email,
             'locale' => $member->language, //OpenID-Connect

--- a/lib/GaletteOAuth2/Controllers/ApiController.php
+++ b/lib/GaletteOAuth2/Controllers/ApiController.php
@@ -85,7 +85,8 @@ final class ApiController extends AbstractPluginController
                     $this->config,
                     $client_id,
                     $rep->getAttribute('oauth_scopes')
-                )
+                ),
+                (bool)$this->config->get($client_id . '.legacy_data', false)
             );
         } catch (UserAuthorizationException $e) {
             UserHelper::logout($this->container);

--- a/lib/GaletteOAuth2/Controllers/LoginController.php
+++ b/lib/GaletteOAuth2/Controllers/LoginController.php
@@ -130,7 +130,8 @@ final class LoginController extends AbstractPluginController
                     $client_id,
                     $this->session->request_args['scope'] ?? [],
                     true
-                )
+                ),
+                (bool)$this->config->get($client_id . '.legacy_data', false)
             );
         } catch (UserAuthorizationException $e) {
             UserHelper::logout($this->container);

--- a/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
+++ b/tests/GaletteOAuth2/Authorization/tests/units/UserHelper.php
@@ -91,6 +91,35 @@ class UserHelper extends GaletteTestCase
         $store = $this->adh->store();
         $this->assertTrue($store);
 
+        //test for default scope - legacy data mode
+        $user_data = \GaletteOAuth2\Authorization\UserHelper::getUserData(
+            $container,
+            $adh1->id,
+            '',
+            ['member'],
+            true
+        );
+
+        $expected_base = [
+            'id' => $adh1->id,
+            'sub' => $adh1->id,
+            'identifier' => $adh1->id,
+            'name' => $adh1->sfullname,
+            'displayName' => $adh1->sname,
+            'username' => 'r.durand',
+            'userName' => 'r.durand',
+            'email' => $adh1->email,
+            'mail' => $adh1->email,
+            'locale' => $adh1->language,
+            'language' => $adh1->language,
+            'status' => $adh1->status,
+        ];
+
+        $this->assertSame(
+            $expected_base,
+            $user_data
+        );
+
         //test for default scope
         $user_data = \GaletteOAuth2\Authorization\UserHelper::getUserData(
             $container,
@@ -105,8 +134,8 @@ class UserHelper extends GaletteTestCase
             'identifier' => $adh1->id,
             'name' => $adh1->sfullname,
             'displayName' => $adh1->sname,
-            'username' => 'r.durand',
-            'userName' => 'r.durand',
+            'username' => $adh1->login,
+            'userName' => $adh1->login,
             'email' => $adh1->email,
             'mail' => $adh1->email,
             'locale' => $adh1->language,

--- a/tests/GaletteOAuth2/GaletteOAuth2.php
+++ b/tests/GaletteOAuth2/GaletteOAuth2.php
@@ -151,7 +151,7 @@ class GaletteOAuth2 extends GaletteTestCase
 
         //check values
         $this->assertSame($adh1->id, $resourceOwner->getId());
-        $this->assertSame('r.durand', $resourceOwner->getUsername()); //not a Galette data
+        $this->assertSame($data['login_adh'], $resourceOwner->getUsername());
         $this->assertSame($data['email_adh'], $resourceOwner->getEmail());
         //due date scope is requested from configuration file
         $this->assertArrayHasKey('due_date', $resourceOwner_array);


### PR DESCRIPTION
Specific data were used instead of Galette login. A legacy mode configuration entry has been added so it's still possible to rely on old data if needed.