### PR TITLE
Add the name of groups the member belongs to

### DIFF
--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -289,7 +289,14 @@ final class UserHelper
      */
     protected static function getUserGroups(Adherent $member): array
     {
-        $groups = [$member->sstatus]; //first group is the member status
+        $groups = array_map(
+            function ($group) {
+                return $group->getName();
+            },
+            $member->getGroups()
+        );
+
+        $groups[] = $member->sstatus;
 
         if ($member->isAdmin()) {
             $groups[] = 'admin';


### PR DESCRIPTION
Hi,

I've just set up a site to authenticate with Galette thanks to this plugin. I'm interested in managing groups on Galette, so that I don't have to do it on the other site. Sadly I quickly discovered that Galette groups weren't part of the `groups` claim, as I was expecting. So here it is.

I've left your comments a few lines below about "should we do this?". I think users will naturally expect that. It's far more convenient: within Galette we can quickly manage groups, assign members, and so on. Whereas `info_adh` is more hidden and error-prone. I haven't removed it because it would be a major breaking change, but feel free to change the comment.

I haven't looked at the tests, if any.