### PR TITLE
Remove keys to groups

### DIFF
--- a/lib/GaletteOAuth2/Authorization/UserHelper.php
+++ b/lib/GaletteOAuth2/Authorization/UserHelper.php
@@ -292,7 +292,7 @@ final class UserHelper
             function ($group) {
                 return $group->getName();
             },
-            $member->getGroups()
+            array_values($member->getGroups())
         );
 
         $groups[] = $member->sstatus;


### PR DESCRIPTION
I realized that groups from `$member->getGroups()` [use id as key](https://github.com/galette/galette/blob/1da504c3b536472e8a8adffd0414e087985985de/galette/lib/Galette/Repository/Groups.php#L214) (I forget that PHP's arrays are actually ordered maps). When these keys are not linear or do not start at 0, the array is JSON-encoded as a map, and not as an array as expected. `array_values` re-indexes the array.